### PR TITLE
fix(ai): correct usage page aggregation

### DIFF
--- a/home/package.json
+++ b/home/package.json
@@ -28,6 +28,7 @@
     "dayjs": "^1.11.19",
     "gray-matter": "^4.0.3",
     "lodash.kebabcase": "^4.1.1",
+    "number-precision": "^1.6.0",
     "react-activity-calendar": "^3.1.1",
     "remark-collapse": "^0.1.2",
     "remark-toc": "^9.0.0",

--- a/home/src/utils/__tests__/ai-usage-loader.test.ts
+++ b/home/src/utils/__tests__/ai-usage-loader.test.ts
@@ -1,6 +1,17 @@
 // home/src/utils/__tests__/ai-usage-loader.test.ts
-import { describe, it, expect } from 'vitest'
-import { detectFileFormat } from '../ai-usage-loader'
+import { afterEach, describe, it, expect } from 'vitest'
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import path from 'path'
+import { detectFileFormat, loadAIUsageData } from '../ai-usage-loader'
+
+const originalCwd = process.cwd()
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  process.chdir(originalCwd)
+  await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })))
+})
 
 describe('detectFileFormat', () => {
   it('should detect Claude Code format', () => {
@@ -34,5 +45,109 @@ describe('detectFileFormat', () => {
       }]
     }
     expect(detectFileFormat(data)).toBe('codex')
+  })
+
+  it('should merge Claude and Codex files for the same device and day', async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), 'ai-usage-loader-'))
+    tempDirs.push(tempDir)
+
+    const usageDir = path.join(tempDir, 'ai', 'usages')
+    await mkdir(usageDir, { recursive: true })
+    process.chdir(tempDir)
+
+    await writeFile(path.join(usageDir, 'jtdeMac-mini-2026-06.json'), JSON.stringify({
+      daily: [{
+        date: '2026-06-04',
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheCreationTokens: 10,
+        cacheReadTokens: 20,
+        totalTokens: 180,
+        totalCost: 0.1,
+        modelsUsed: ['claude-sonnet-4-6'],
+        modelBreakdowns: [{
+          modelName: 'claude-sonnet-4-6',
+          inputTokens: 100,
+          outputTokens: 50,
+          cacheCreationTokens: 10,
+          cacheReadTokens: 20,
+          cost: 0.1
+        }]
+      }]
+    }))
+
+    await writeFile(path.join(usageDir, 'jtdeMac-mini-codex-2026-06.json'), JSON.stringify({
+      daily: [{
+        date: 'Jun 04, 2026',
+        inputTokens: 200,
+        cachedInputTokens: 60,
+        outputTokens: 40,
+        reasoningOutputTokens: 10,
+        totalTokens: 240,
+        costUSD: 0.2,
+        models: {
+          'gpt-5.3-codex': {
+            inputTokens: 200,
+            cachedInputTokens: 60,
+            outputTokens: 40,
+            reasoningOutputTokens: 10,
+            totalTokens: 240,
+            isFallback: false
+          }
+        }
+      }]
+    }))
+
+    const data = await loadAIUsageData()
+
+    expect(data.summary.deviceList).toEqual(['jtdeMac-mini'])
+    expect(data.byDevice['jtdeMac-mini'].byMonth['2026-06']).toHaveLength(1)
+
+    const mergedDay = data.byDevice['jtdeMac-mini'].byMonth['2026-06'][0]
+    expect(mergedDay.totalTokens).toBe(420)
+    expect(mergedDay.totalCost).toBe(0.3)
+    expect(mergedDay.modelsUsed).toEqual(['claude-sonnet-4-6', 'gpt-5.3-codex'])
+    expect(mergedDay.modelBreakdowns).toHaveLength(2)
+  })
+
+  it('should use the latest same-tool snapshot instead of double-counting history files', async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), 'ai-usage-loader-'))
+    tempDirs.push(tempDir)
+
+    const usageDir = path.join(tempDir, 'ai', 'usages')
+    await mkdir(usageDir, { recursive: true })
+    process.chdir(tempDir)
+
+    const createClaudeSnapshot = (totalTokens: number, totalCost: number) => ({
+      daily: [{
+        date: '2026-03-01',
+        inputTokens: totalTokens,
+        outputTokens: 0,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+        totalTokens,
+        totalCost,
+        modelsUsed: ['claude-sonnet-4-6'],
+        modelBreakdowns: [{
+          modelName: 'claude-sonnet-4-6',
+          inputTokens: totalTokens,
+          outputTokens: 0,
+          cacheCreationTokens: 0,
+          cacheReadTokens: 0,
+          cost: totalCost
+        }]
+      }]
+    })
+
+    await writeFile(path.join(usageDir, 'jtdeMac-mini-2026-03.json'), JSON.stringify(createClaudeSnapshot(100, 0.1)))
+    await writeFile(path.join(usageDir, 'jtdeMac-mini-2026-04.json'), JSON.stringify(createClaudeSnapshot(200, 0.2)))
+
+    const data = await loadAIUsageData()
+    const day = data.byDevice['jtdeMac-mini'].byMonth['2026-03'][0]
+
+    expect(day.totalTokens).toBe(200)
+    expect(day.totalCost).toBe(0.2)
+    expect(data.summary.totalTokens).toBe(200)
+    expect(data.summary.totalCost).toBe(0.2)
   })
 })

--- a/home/src/utils/__tests__/ai-usage.test.ts
+++ b/home/src/utils/__tests__/ai-usage.test.ts
@@ -22,6 +22,11 @@ describe('parseDeviceFilename', () => {
     const result = parseDeviceFilename('home-macbook-2026-03-07.json')
     expect(result).toEqual({ deviceName: 'home-macbook', yearMonth: '2026-03' })
   })
+
+  it('should parse Codex usage filename as the original device', () => {
+    const result = parseDeviceFilename('jtdeMac-mini-codex-2026-06.json')
+    expect(result).toEqual({ deviceName: 'jtdeMac-mini', yearMonth: '2026-06' })
+  })
 })
 
 describe('calculateSummary', () => {
@@ -53,5 +58,35 @@ describe('calculateSummary', () => {
     expect(result.totalTokens).toBe(1700)
     expect(result.totalCost).toBe(0.01)
     expect(result.byModel['claude-sonnet-4-6']).toBe(1700)
+  })
+
+  it('should calculate cost totals with decimal precision', () => {
+    const daily: DailyUsage[] = [
+      {
+        date: '2026-03-01',
+        inputTokens: 1000,
+        outputTokens: 500,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 200,
+        totalTokens: 1700,
+        totalCost: 0.1,
+        modelsUsed: ['claude-sonnet-4-6'],
+        modelBreakdowns: []
+      },
+      {
+        date: '2026-03-02',
+        inputTokens: 1000,
+        outputTokens: 500,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 200,
+        totalTokens: 1700,
+        totalCost: 0.2,
+        modelsUsed: ['gpt-5.3-codex'],
+        modelBreakdowns: []
+      }
+    ]
+
+    const result = calculateSummary(daily)
+    expect(result.totalCost).toBe(0.3)
   })
 })

--- a/home/src/utils/ai-usage-loader.ts
+++ b/home/src/utils/ai-usage-loader.ts
@@ -1,11 +1,16 @@
 // src/utils/ai-usage-loader.ts
 import fs from 'fs/promises'
 import path from 'path'
-import type { AIUsageData, DeviceMonthlyData, ProcessedDeviceData, DailyUsage, CodexUsageData } from '../types/ai-usage'
+import NP from 'number-precision'
+import type { AIUsageData, DeviceMonthlyData, ProcessedDeviceData, DailyUsage, CodexUsageData, ModelBreakdown } from '../types/ai-usage'
 import { parseDeviceFilename, calculateSummary, aggregateByMonth } from './ai-usage'
 import { normalizeCodexData } from './codex-usage'
 
-const USAGE_DIR = path.join(process.cwd(), 'ai', 'usages')
+NP.enableBoundaryChecking(false)
+
+function getUsageDir() {
+  return path.join(process.cwd(), 'ai', 'usages')
+}
 
 type FileFormat = 'claude-code' | 'codex'
 
@@ -39,18 +44,25 @@ export function detectFileFormat(data: unknown): FileFormat {
 
 export async function loadAIUsageData(): Promise<AIUsageData> {
   const byDevice: Record<string, ProcessedDeviceData> = {}
+  const byDeviceDate: Record<string, Map<string, Partial<Record<FileFormat, DailyUsage>>>> = {}
   let allDaily: DailyUsage[] = []
 
   try {
-    const files = await fs.readdir(USAGE_DIR)
-    const jsonFiles = files.filter(f => f.endsWith('.json') && !f.startsWith('.'))
+    const usageDir = getUsageDir()
+    const files = await fs.readdir(usageDir)
+    const jsonFiles = files
+      .filter(f => f.endsWith('.json') && !f.startsWith('.'))
+      .sort((a, b) => {
+        const dateCompare = getSnapshotSortKey(a).localeCompare(getSnapshotSortKey(b))
+        return dateCompare || a.localeCompare(b)
+      })
 
     for (const file of jsonFiles) {
       const parsed = parseDeviceFilename(file)
       if (!parsed) continue
 
-      const { deviceName, yearMonth } = parsed
-      const filePath = path.join(USAGE_DIR, file)
+      const { deviceName } = parsed
+      const filePath = path.join(usageDir, file)
       const content = await fs.readFile(filePath, 'utf-8')
       const rawData = JSON.parse(content)
 
@@ -60,21 +72,35 @@ export async function loadAIUsageData(): Promise<AIUsageData> {
         ? normalizeCodexData(rawData as CodexUsageData)
         : (rawData as DeviceMonthlyData).daily
 
-      if (!byDevice[deviceName]) {
-        byDevice[deviceName] = { byMonth: {} }
+      if (!byDeviceDate[deviceName]) {
+        byDeviceDate[deviceName] = new Map()
       }
 
-      // Merge if same device-month exists
-      const existing = byDevice[deviceName].byMonth[yearMonth] || []
-      byDevice[deviceName].byMonth[yearMonth] = mergeDailyData(existing, dailyData)
-      allDaily = allDaily.concat(dailyData)
+      for (const day of dailyData) {
+        const dailyByFormat = byDeviceDate[deviceName].get(day.date) || {}
+        dailyByFormat[format] = cloneDailyUsage(day)
+        byDeviceDate[deviceName].set(day.date, dailyByFormat)
+      }
     }
   } catch (error) {
     // Directory doesn't exist or is empty
     console.warn('No AI usage data found:', error)
   }
 
-  // Calculate total (all devices merged)
+  for (const [deviceName, dailyByDate] of Object.entries(byDeviceDate)) {
+    const deviceDaily = Array.from(dailyByDate.entries())
+      .map(([, dailyByFormat]) => mergeDailyData([], Object.values(dailyByFormat) as DailyUsage[]))
+      .flat()
+      .sort((a, b) => a.date.localeCompare(b.date))
+
+    byDevice[deviceName] = {
+      byMonth: aggregateByMonth(deviceDaily)
+    }
+
+    allDaily = mergeDailyData(allDaily, deviceDaily)
+  }
+
+  // Calculate total (all devices merged by actual usage date)
   const totalByMonth = aggregateByMonth(allDaily)
 
   // Calculate summary
@@ -85,21 +111,69 @@ export async function loadAIUsageData(): Promise<AIUsageData> {
     total: { byMonth: totalByMonth },
     summary: {
       ...summary,
-      deviceList: Object.keys(byDevice)
+      deviceList: Object.keys(byDevice).sort()
     }
   }
+}
+
+function getSnapshotSortKey(filename: string) {
+  const match = filename.match(/-(\d{4}-\d{2}(?:-\d{2})?)\.json$/)
+  return match?.[1] || ''
 }
 
 function mergeDailyData(existing: DailyUsage[], incoming: DailyUsage[]) {
   const merged = new Map<string, DailyUsage>()
 
   for (const day of existing) {
-    merged.set(day.date, day)
+    merged.set(day.date, cloneDailyUsage(day))
   }
 
   for (const day of incoming) {
-    merged.set(day.date, day)
+    const current = merged.get(day.date)
+    merged.set(day.date, current ? mergeDailyUsage(current, day) : cloneDailyUsage(day))
   }
 
   return Array.from(merged.values()).sort((a, b) => a.date.localeCompare(b.date))
+}
+
+function cloneDailyUsage(day: DailyUsage): DailyUsage {
+  return {
+    ...day,
+    modelsUsed: [...day.modelsUsed],
+    modelBreakdowns: day.modelBreakdowns.map(breakdown => ({ ...breakdown }))
+  }
+}
+
+function mergeDailyUsage(left: DailyUsage, right: DailyUsage): DailyUsage {
+  return {
+    date: left.date,
+    inputTokens: left.inputTokens + right.inputTokens,
+    outputTokens: left.outputTokens + right.outputTokens,
+    cacheCreationTokens: left.cacheCreationTokens + right.cacheCreationTokens,
+    cacheReadTokens: left.cacheReadTokens + right.cacheReadTokens,
+    totalTokens: left.totalTokens + right.totalTokens,
+    totalCost: NP.plus(left.totalCost, right.totalCost),
+    modelsUsed: Array.from(new Set([...left.modelsUsed, ...right.modelsUsed])).sort(),
+    modelBreakdowns: mergeModelBreakdowns(left.modelBreakdowns, right.modelBreakdowns)
+  }
+}
+
+function mergeModelBreakdowns(left: ModelBreakdown[], right: ModelBreakdown[]) {
+  const merged = new Map<string, ModelBreakdown>()
+
+  for (const breakdown of [...left, ...right]) {
+    const current = merged.get(breakdown.modelName)
+    if (!current) {
+      merged.set(breakdown.modelName, { ...breakdown })
+      continue
+    }
+
+    current.inputTokens += breakdown.inputTokens
+    current.outputTokens += breakdown.outputTokens
+    current.cacheCreationTokens += breakdown.cacheCreationTokens
+    current.cacheReadTokens += breakdown.cacheReadTokens
+    current.cost = NP.plus(current.cost, breakdown.cost)
+  }
+
+  return Array.from(merged.values()).sort((a, b) => a.modelName.localeCompare(b.modelName))
 }

--- a/home/src/utils/ai-usage.ts
+++ b/home/src/utils/ai-usage.ts
@@ -1,5 +1,8 @@
 // src/utils/ai-usage.ts
+import NP from 'number-precision'
 import type { DailyUsage } from '../types/ai-usage'
+
+NP.enableBoundaryChecking(false)
 
 export function parseDeviceFilename(filename: string): { deviceName: string; yearMonth: string } | null {
   // 支持格式: {设备名}-{YYYY-MM-DD}.json 或 {设备名}-{YYYY-MM}.json
@@ -8,8 +11,12 @@ export function parseDeviceFilename(filename: string): { deviceName: string; yea
   const datePart = match[2]
   // 提取年月 (YYYY-MM)
   const yearMonth = datePart.substring(0, 7)
+  const deviceName = match[1].endsWith('-codex')
+    ? match[1].slice(0, -'-codex'.length)
+    : match[1]
+
   return {
-    deviceName: match[1],
+    deviceName,
     yearMonth
   }
 }
@@ -21,7 +28,7 @@ export function calculateSummary(daily: DailyUsage[]) {
 
   for (const day of daily) {
     totalTokens += day.totalTokens
-    totalCost += day.totalCost
+    totalCost = NP.plus(totalCost, day.totalCost)
 
     for (const breakdown of day.modelBreakdowns) {
       const modelTokens = breakdown.inputTokens + breakdown.outputTokens + breakdown.cacheReadTokens


### PR DESCRIPTION
## 背景

AI usage 同步恢复后，博客 `/ai` 页面仍存在统计口径问题：`*-codex-YYYY-MM.json` 会被识别为独立设备，并且历史累计快照文件会被重复纳入统计。

## 变更

- 将 Codex usage 文件归并回原设备名，例如 `jtdeMac-mini-codex-2026-06.json` -> `jtdeMac-mini`。
- 按“设备 + 实际日期 + 工具类型”归并数据：同一工具的历史快照使用最新文件覆盖，Claude 与 Codex 同日数据再累加。
- 引入 `number-precision` 处理 cost 累加，避免 `0.1 + 0.2` 这类浮点误差。
- 补充回归测试覆盖设备归属、多工具合并、历史快照去重和 cost 精度。

## 验证

- `npm run test -- --run src/utils/__tests__/ai-usage.test.ts src/utils/__tests__/ai-usage-loader.test.ts src/utils/__tests__/codex-usage.test.ts`：通过，19 tests。
- `npx eslint src/utils/ai-usage.ts src/utils/ai-usage-loader.ts src/utils/__tests__/ai-usage.test.ts src/utils/__tests__/ai-usage-loader.test.ts src/utils/__tests__/codex-usage.test.ts`：通过。
- `npm run build`：通过，60 pages built，`BOUNDARY_WARNINGS=0`。
- loader 实测：devices 为 `home-macbook`, `home-macmini`, `jtdeMac-mini`；无 `jtdeMac-mini-codex` 伪设备；`jtdeMac-mini` 重复日期数为 0；最新日期为 `2026-06-04`。

## 已知情况

- `npm run lint` 全量仍失败，失败点为仓库既有问题，例如 `bin/*.cjs` 的 require 规则、若干未使用变量，以及部分 Astro 文件的既有 lint 错误；本 PR 的改动文件已通过定向 ESLint。

## English Summary

Fixes the blog AI usage page aggregation by mapping Codex files back to the original device, deduplicating cumulative historical snapshots, merging same-day Claude and Codex usage, and using `number-precision` for cost arithmetic.