### PR TITLE
fix(blog): move language switcher after archives

### DIFF
--- a/home/src/components/Header.astro
+++ b/home/src/components/Header.astro
@@ -148,6 +148,43 @@ const isActive = (path: string) => {
             </li>
           )
         }
+        <li class="col-span-2 flex items-center justify-center sm:col-span-1">
+          <details class="group relative">
+            <summary
+              class="focus-outline flex cursor-pointer list-none items-center gap-1 rounded px-3 py-3 text-sm font-medium hover:text-accent sm:px-1 sm:py-1"
+              aria-label={t(locale, "language")}
+            >
+              {LANGUAGE_LABELS[locale]}
+              <span
+                aria-hidden="true"
+                class="text-xs transition-transform group-open:rotate-180"
+                >▾</span
+              >
+            </summary>
+            <ul
+              class="absolute end-0 z-50 mt-1 hidden min-w-36 rounded border border-border bg-background p-1 shadow-lg group-open:block"
+            >
+              {
+                SUPPORTED_LOCALES.map(targetLocale => (
+                  <li>
+                    <a
+                      href={getLanguagePath(targetLocale)}
+                      aria-current={
+                        targetLocale === locale ? "page" : undefined
+                      }
+                      class:list={[
+                        "block rounded px-3 py-2 text-sm hover:bg-muted hover:text-accent",
+                        { "bg-muted text-accent": targetLocale === locale },
+                      ]}
+                    >
+                      {LANGUAGE_LABELS[targetLocale]}
+                    </a>
+                  </li>
+                ))
+              }
+            </ul>
+          </details>
+        </li>
         <li class="col-span-1 flex items-center justify-center">
           <LinkButton
             href={localPath("/search")}
@@ -189,43 +226,6 @@ const isActive = (path: string) => {
             </li>
           )
         }
-        <li class="col-span-2 flex items-center justify-center sm:col-span-1">
-          <details class="group relative">
-            <summary
-              class="focus-outline flex cursor-pointer list-none items-center gap-1 rounded px-3 py-3 text-sm font-medium hover:text-accent sm:px-1 sm:py-1"
-              aria-label={t(locale, "language")}
-            >
-              {LANGUAGE_LABELS[locale]}
-              <span
-                aria-hidden="true"
-                class="text-xs transition-transform group-open:rotate-180"
-                >▾</span
-              >
-            </summary>
-            <ul
-              class="absolute end-0 z-50 mt-1 hidden min-w-36 rounded border border-border bg-background p-1 shadow-lg group-open:block"
-            >
-              {
-                SUPPORTED_LOCALES.map(targetLocale => (
-                  <li>
-                    <a
-                      href={getLanguagePath(targetLocale)}
-                      aria-current={
-                        targetLocale === locale ? "page" : undefined
-                      }
-                      class:list={[
-                        "block rounded px-3 py-2 text-sm hover:bg-muted hover:text-accent",
-                        { "bg-muted text-accent": targetLocale === locale },
-                      ]}
-                    >
-                      {LANGUAGE_LABELS[targetLocale]}
-                    </a>
-                  </li>
-                ))
-              }
-            </ul>
-          </details>
-        </li>
       </ul>
     </nav>
   </div>


### PR DESCRIPTION
## 摘要 / Summary

将多语言切换器移动到归档入口之后、搜索入口之前；移动端和桌面端顺序一致。

Move the language selector after the Archives navigation item and before Search in both mobile and desktop navigation.

## 变更 / Changes

- 调整 Header.astro 中语言菜单的位置，未修改菜单行为或语言链接。
- Reorder the language menu without changing its behavior or locale links.

## 关联事项 / Related Issues

无匹配的开放 Issue。 / No matching open issue.

## 验证 / Testing

- [x] Prettier 针对性格式检查通过。
- [x] ESLint 针对性检查通过。
- [x] npm run build 通过。
- [x] 生产预览中 /、/en/、/zh-TW/ 的归档、语言、搜索顺序正确。
- [ ] npm test：3 个既有失败套件（Astro 内容模块解析及图片 URL 断言），与本改动无关。
- [ ] npm run lint：57 个既有错误，均不在 Header.astro。

## 检查清单 / Checklist

- [x] 未暴露敏感数据 / No sensitive data exposed
- [x] 已完成针对性格式与 lint 检查 / Targeted formatting and lint checks passed
- [x] 无破坏性变更 / No breaking changes